### PR TITLE
I made some modifications to the code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Go template
+# Binaries for programs and plugins
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
+.glide/
+

--- a/storages/filesystem.go
+++ b/storages/filesystem.go
@@ -20,8 +20,9 @@ func (s *Filesystem) Init(root string) error {
 
 func (s *Filesystem) Code() string {
 	s.Lock()
+	defer s.Unlock()
+
 	files, _ := ioutil.ReadDir(s.Root)
-	s.Unlock()
 
 	return strconv.FormatUint(uint64(len(files)+1), 36)
 }
@@ -30,16 +31,18 @@ func (s *Filesystem) Save(url string) string {
 	code := s.Code()
 
 	s.Lock()
+	defer  s.Unlock()
+
 	ioutil.WriteFile(filepath.Join(s.Root, code), []byte(url), 0744)
-	s.Unlock()
 
 	return code
 }
 
 func (s *Filesystem) Load(code string) (string, error) {
 	s.Lock()
+	defer s.Unlock()
+
 	urlBytes, err := ioutil.ReadFile(filepath.Join(s.Root, code))
-	s.Unlock()
 
 	return string(urlBytes), err
 }


### PR DESCRIPTION
- In the handlers, there's no verb handling, meaning all operations accept GET, POST, PUT, PATCH... requests. 
- There's no graceful shutdown, which means that the files being written may be kept captive from their file descriptors.
- runtime.GOMAXPROCS(runtime.NumCPU()) is no longer needed since a couple of Go versions ago. Now the runtime makes this decision automatically, pretty much with the same code you had before. By doing this here, it interferes with the ability of a Go program to allow the end user to pass an env var that may change this value later on.